### PR TITLE
Fix line coalescing

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -25,7 +25,7 @@ Whisper = {
 	},
 
 	getSenderNick: function(sender) {
-		if (sender) { return sender.getAttribute('nickname'); }
+		if (sender) { return sender.getAttribute('data-nickname'); }
 	},
 
 	getPreviousLine: function(line) {
@@ -36,7 +36,7 @@ Whisper = {
 	},
 
 	getLineType: function(line) {
-		return line ? line.getAttribute('ltype') : null;
+		return line ? line.getAttribute('data-line-type') : null;
 	},
 
 	coalesceLines: function(lineNum) {
@@ -138,7 +138,7 @@ Textual.viewFinishedReload = function()
 	Textual.viewFinishedLoading();
 };
 
-Textual.newMessagePostedToView = function (lineNum) {
+Textual.messageAddedToView = function (lineNum, fromBuffer) {
 	Whisper.coalesceLines(lineNum);
 	
 	var element = document.getElementById("line-" + lineNum);


### PR DESCRIPTION
This is a feature that was in the original Whisper stylesheet and got broken over time due to minor changes in Textual. These small fixes bring the feature back.
This causes nicknames to only be printed on the first line of subsequent messages, rather than on every line.
![rzuoxj](https://user-images.githubusercontent.com/4523694/62010473-d9ac3900-b130-11e9-8bdb-da6ac0d81892.png)


